### PR TITLE
Add README shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+.dotfiles/README.md


### PR DESCRIPTION
Adds a shortcut to `.dotfiles/README.md` on the root directory so that GitHub displays the README file contents on the repository's home page.