### PR TITLE
feat: configure `git` and `lazygit` to use `delta`

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json
+git:
+  paging:
+    colorArg: always
+    pager: delta --dark --color-only --paging=never

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,16 +1,33 @@
 [user]
-	name = Ta-Seen Islam
+	name = Ta-Seen
 	email = taseen00.islam@gmail.com
+
 [core]
 	editor = nvim
-[init]
-	defaultBranch = main
-[pull]
-	ff = only
+	pager = delta
+
 [commit]
 	gpgsign = true
+
+[delta]
+	navigate = true
+	syntax-theme = Kanagawa
+
 [diff]
+	colorMoved = default
 	submodule = log
+
+[init]
+	defaultBranch = main
+
+[interactive]
+	diffFilter = delta --color-only
+
+[merge]
+	conflictStyle = diff3
+
+[pull]
+	ff = only
 
 # The contents of this file are included only for GitLab.com URLs
 [includeIf "hasconfig:remote.*.url:https://code.research.uts.edu.au/**"]


### PR DESCRIPTION
This change configures `git` and `lazygit` to use `delta` as the default pager and diff tool.