### PR TITLE
chore(kitty): open new tabs and windows with CWD

### DIFF
--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -1773,10 +1773,6 @@ font_size 14.15
 #:     # multi-key shortcuts
 #:     map ctrl+x>ctrl+y>z action
 
-# Always open new tabs at current work directory
-# https://github.com/kovidgoyal/kitty/issues/692#issuecomment-1199125196
-map cmd+t launch --cwd=current --type=tab
-
 #: The full list of actions that can be mapped to key presses is
 #: available here <https://sw.kovidgoyal.net/kitty/actions/>.
 
@@ -1957,8 +1953,8 @@ map cmd+t launch --cwd=current --type=tab
 
 #: New window
 
-# map kitty_mod+enter new_window
-# map cmd+enter       new_window
+map kitty_mod+enter new_window_with_cwd
+map cmd+enter       new_window_with_cwd
 
 #::  You can open a new kitty window running an arbitrary program, for
 #::  example::
@@ -1988,8 +1984,8 @@ map cmd+t launch --cwd=current --type=tab
 
 #: New OS window
 
-# map kitty_mod+n new_os_window
-# map cmd+n       new_os_window
+map kitty_mod+n new_os_window_with_cwd
+map cmd+n       new_os_window_with_cwd
 
 #::  Works like new_window above, except that it opens a top-level OS
 #::  window. In particular you can use new_os_window_with_cwd to open
@@ -2108,8 +2104,8 @@ map cmd+t launch --cwd=current --type=tab
 
 #: New tab
 
-# map kitty_mod+t new_tab
-# map cmd+t       new_tab
+map kitty_mod+t new_tab_with_cwd
+map cmd+t       new_tab_with_cwd
 
 #: Close tab
 

--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -6,7 +6,7 @@
 #: individual font faces and even specify special fonts for particular
 #: characters.
 
-font_family      Input
+font_family      DM Mono
 bold_font        auto
 italic_font      auto
 bold_italic_font auto
@@ -26,7 +26,7 @@ bold_italic_font auto
 
 #: Font size (in pts)
 
-font_size 13.0
+font_size 14.15
 
 # force_ltr no
 
@@ -1772,6 +1772,10 @@ font_size 13.0
 #:     map kitty_mod+e combine : new_window : next_layout
 #:     # multi-key shortcuts
 #:     map ctrl+x>ctrl+y>z action
+
+# Always open new tabs at current work directory
+# https://github.com/kovidgoyal/kitty/issues/692#issuecomment-1199125196
+map cmd+t launch --cwd=current --type=tab
 
 #: The full list of actions that can be mapped to key presses is
 #: available here <https://sw.kovidgoyal.net/kitty/actions/>.


### PR DESCRIPTION
This change remaps the default "New window", "New OS window" and "New tab" shortcuts to always open the shell at the current working directory.

This change also applies the following minor improvements:

- Set the `font_family` to `DM Mono`
- Increase `font_size` to `14.15`
