### PR TITLE
chore(zsh): refactor config files

### DIFF
--- a/.config/zsh/.zprofile
+++ b/.config/zsh/.zprofile
@@ -3,9 +3,9 @@
 # .zprofile - Zsh file loaded on login.
 #
 
-# NOTE: To avoid potential issues that `path_helper` may cause when prepending
-# appending and prepending to `$PATH`, all environment variables will be set
-# in this file. Refer to the link below for more information.
+# NOTE: To avoid `path_helper` causing potential issues when appending and
+# prepending to `$PATH`, all environment variables will be set in this file.
+# Please refer to the link below for more information.
 #
 # > For zsh, the order is like this:
 # > 1. `/etc/zshenv` (no longer exists on macOS by default)

--- a/.config/zsh/.zprofile
+++ b/.config/zsh/.zprofile
@@ -3,7 +3,7 @@
 # .zprofile - Zsh file loaded on login.
 #
 
-# NOTE: To avoid `path_helper` causing potential issues when appending and
+# NOTE: To avoid `path_helper` from causing potential issues when appending and
 # prepending to `$PATH`, all environment variables will be set in this file.
 # Please refer to the link below for more information.
 #
@@ -18,8 +18,8 @@
 #
 # SEE: https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
 
-case "$HOST" in
-  taseen-macbook-work.local)
+case "$SHORT_HOST" in
+  taseen-macbook-work)
     # PNPM
     export PNPM_HOME="$HOME/Library/pnpm"
     export PATH="$PNPM_HOME:$PATH"
@@ -35,7 +35,7 @@ case "$HOST" in
     export CHROME_EXECUTABLE="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
 
     # Added by Toolbox App
-    # TODO: This appears to be redudant?
+    # TODO: This appears to be redundant?
     export PATH="$PATH:/usr/local/bin"
 
     # Added by Docker Desktop

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -6,6 +6,32 @@
 # Path to your oh-my-zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
 
+# Zsh history file
+ZSH_HISTFILE_HOME="$XDG_STATE_HOME/zsh"
+export HISTFILE="$ZSH_HISTFILE_HOME/history"
+[ -d $ZSH_HISTFILE_HOME ] || mkdir -p $ZSH_HISTFILE_HOME
+
+# Prefer "$XDG_CACHE_HOME/zsh" as cache directory if possible.
+if (( ${+XDG_CACHE_HOME} )); then
+  export ZSH_CACHE_DIR="$XDG_CACHE_HOME/zsh"
+else
+  export ZSH_CACHE_DIR="$ZSH/cache" # Default set by oh-my-zsh
+fi
+
+# Create the cache directory if it doesn't exist.
+[ -d $ZSH_CACHE_DIR ] || mkdir -p $ZSH_CACHE_DIR
+
+# Dump completion artefacts into a cache directory, appended with the machine's
+# hostname (without any domain information^1) and current ZSH version.
+#
+# Borrowed from:
+# - https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624221366
+# - https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624451063
+#
+# [1]: Equivalent to `hostname -s` on BSD systems
+#      https://man.freebsd.org/cgi/man.cgi?hostname(1)
+export ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${HOST/.*/}-${ZSH_VERSION}"
+
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
@@ -70,25 +96,6 @@ plugins=(
   zsh-defer
   zsh-syntax-highlighting
 )
-
-# By default, OMZ sets the cache directory to "$ZSH/cache", but we'll prefer
-# "$XDG_CACHE_HOME/zsh" if possible.
-if (( ${+XDG_CACHE_HOME} )); then
-  export ZSH_CACHE_DIR="$XDG_CACHE_HOME/zsh"
-else
-  export ZSH_CACHE_DIR="$ZSH/cache"
-fi
-
-# Dump completion artefacts into a cache directory, appended with the machine's
-# hostname (without any domain information^1) and current ZSH version.
-#
-# Borrowed from:
-# - https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624221366
-# - https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624451063
-#
-# [1]: Equivalent to `hostname -s` on BSD systems
-#      https://man.freebsd.org/cgi/man.cgi?hostname(1)
-export ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${HOST/.*/}-${ZSH_VERSION}"
 
 source $ZSH/oh-my-zsh.sh
 

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -9,7 +9,7 @@ export ZSH="$HOME/.oh-my-zsh"
 # Zsh history file
 ZSH_HISTFILE_HOME="$XDG_STATE_HOME/zsh"
 export HISTFILE="$ZSH_HISTFILE_HOME/history"
-[ -d $ZSH_HISTFILE_HOME ] || mkdir -p $ZSH_HISTFILE_HOME
+[ -d "$ZSH_HISTFILE_HOME" ] || mkdir -p "$ZSH_HISTFILE_HOME"
 
 # Prefer "$XDG_CACHE_HOME/zsh" as cache directory if possible.
 if (( ${+XDG_CACHE_HOME} )); then
@@ -19,18 +19,16 @@ else
 fi
 
 # Create the cache directory if it doesn't exist.
-[ -d $ZSH_CACHE_DIR ] || mkdir -p $ZSH_CACHE_DIR
+[ -d "$ZSH_CACHE_DIR" ] || mkdir -p "$ZSH_CACHE_DIR"
 
 # Dump completion artefacts into a cache directory, appended with the machine's
-# hostname (without any domain information^1) and current ZSH version.
+# hostname without any domain information (refer to `~/.profile` for more
+# information) and the current Zsh version.
 #
 # Borrowed from:
 # - https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624221366
 # - https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624451063
-#
-# [1]: Equivalent to `hostname -s` on BSD systems
-#      https://man.freebsd.org/cgi/man.cgi?hostname(1)
-export ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${HOST/.*/}-${ZSH_VERSION}"
+export ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time oh-my-zsh is loaded, in which case,

--- a/.profile
+++ b/.profile
@@ -1,11 +1,9 @@
 # Set default editor to Neovim
 export EDITOR=nvim
 
+# TODO: Ensure configurations that respect this are moved to this directory
 # Set default configuration folder to `~/.config`
 export XDG_CONFIG_HOME="$HOME/.config"
-
-# TODO: Move all Zsh config files EXCEPT .zshenv
-# export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 
 case "$HOST" in
   taseen-macbook-work.local)

--- a/.profile
+++ b/.profile
@@ -6,25 +6,45 @@
 # Set default editor to Neovim
 export EDITOR=nvim
 
+# BSD systems append domain information to the hostname, for example:
+#
+#     taseen-macbook-work.local
+#
+# Since `ComputerName` does not have this detail appended, we'll attempt to use
+# it if possible. Otherwise, use the hostname as provided and strip of the end
+# by substituting it with an empty string instead.
+#
+# This behaviour is equivalent to `hostname -s` on BSD systems:
+# - https://man.freebsd.org/cgi/man.cgi?hostname(1)
+#
+# Borrowed from oh-my-zsh's source code:
+# - https://github.com/ohmyzsh/ohmyzsh/blob/0fed36688f9a60d8b1f2182f27de7fdc8a1e6b72/oh-my-zsh.sh#L104-L110
+if [[ "$OSTYPE" = darwin* ]]; then
+  # macOS's $HOST changes with dhcp, etc. Use ComputerName if possible.
+  export SHORT_HOST=$(scutil --get ComputerName 2>/dev/null) || SHORT_HOST="${HOST/.*/}"
+else
+  export SHORT_HOST="${HOST/.*/}"
+fi
+
 # NOTE: Adhere to the XDG Base Directory specification, even on macOS.
 
 # Directory for user-specific configuration files
 export XDG_CONFIG_HOME="$HOME/.config"
-[ -d $XDG_CONFIG_HOME ] || mkdir -p $XDG_CONFIG_HOME
+[ -d "$XDG_CONFIG_HOME" ] || mkdir -p "$XDG_CONFIG_HOME"
 
 # Directory for user-specific non-essential (cached) data
 export XDG_CACHE_HOME="$HOME/.cache"
-[ -d $XDG_CACHE_HOME ] || mkdir -p $XDG_CACHE_HOME
+[ -d "$XDG_CACHE_HOME" ] || mkdir -p "$XDG_CACHE_HOME"
 
 # Directory for user-specific data files
 export XDG_DATA_HOME="$HOME/.local/share"
-[ -d $XDG_DATA_HOME ] || mkdir -p $XDG_DATA_HOME
+[ -d "$XDG_DATA_HOME" ] || mkdir -p "$XDG_DATA_HOME"
 
 # Directory for user-specific state files
 export XDG_STATE_HOME="$HOME/.local/state"
-[ -d $XDG_STATE_HOME ] || mkdir -p $XDG_STATE_HOME
+[ -d "$XDG_STATE_HOME" ] || mkdir -p "$XDG_STATE_HOME"
 
 # Bash history file
 BASH_HISTFILE_HOME="$XDG_STATE_HOME/bash"
 export HISTFILE="$BASH_HISTFILE_HOME/history"
-[ -d $BASH_HISTFILE_HOME ] || mkdir -p $BASH_HISTFILE_HOME
+[ -d "$BASH_HISTFILE_HOME" ] || mkdir -p "$BASH_HISTFILE_HOME"

--- a/.profile
+++ b/.profile
@@ -1,37 +1,12 @@
+#!/bin/sh
+#
+# .profile - Bash file loaded on login. Also sourced from `.zshenv`.
+#
+
 # Set default editor to Neovim
 export EDITOR=nvim
 
-# TODO: Ensure configurations that respect this are moved to this directory
-# Set default configuration folder to `~/.config`
+# TODO: Ensure to move configurations if their programs respect these
 export XDG_CONFIG_HOME="$HOME/.config"
-
-case "$HOST" in
-  taseen-macbook-work.local)
-    # PNPM
-    export PNPM_HOME="$HOME/Library/pnpm"
-    export PATH="$PNPM_HOME:$PATH"
-
-    # Android
-    export ANDROID_HOME="$HOME/Library/Android/sdk"
-    export PATH="$PATH:$ANDROID_HOME/emulator"
-    export PATH="$PATH:$ANDROID_HOME/tools"
-    export PATH="$PATH:$ANDROID_HOME/tools/bin"
-    export PATH="$PATH:$ANDROID_HOME/platform-tools"
-
-    # Flutter requires `CHROME_EXECUTABLE` to develop for the web
-    export CHROME_EXECUTABLE="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
-
-    # Added by Toolbox App
-    export PATH="$PATH:/usr/local/bin"
-
-    # Added by Docker Desktop
-    source "$HOME/.docker/init-bash.sh" || true
-
-    # Added by Cargo
-    . "$HOME/.cargo/env"
-    ;;
-
-  taseen-mint)
-    # Nothing here yet...
-    ;;
-esac
+# export XDG_CACHE_HOME="$HOME/.cache"
+# export XDG_DATA_HOME="$HOME/.local/share"

--- a/.profile
+++ b/.profile
@@ -6,7 +6,25 @@
 # Set default editor to Neovim
 export EDITOR=nvim
 
-# TODO: Ensure to move configurations if their programs respect these
+# NOTE: Adhere to the XDG Base Directory specification, even on macOS.
+
+# Directory for user-specific configuration files
 export XDG_CONFIG_HOME="$HOME/.config"
-# export XDG_CACHE_HOME="$HOME/.cache"
-# export XDG_DATA_HOME="$HOME/.local/share"
+[ -d $XDG_CONFIG_HOME ] || mkdir -p $XDG_CONFIG_HOME
+
+# Directory for user-specific non-essential (cached) data
+export XDG_CACHE_HOME="$HOME/.cache"
+[ -d $XDG_CACHE_HOME ] || mkdir -p $XDG_CACHE_HOME
+
+# Directory for user-specific data files
+export XDG_DATA_HOME="$HOME/.local/share"
+[ -d $XDG_DATA_HOME ] || mkdir -p $XDG_DATA_HOME
+
+# Directory for user-specific state files
+export XDG_STATE_HOME="$HOME/.local/state"
+[ -d $XDG_STATE_HOME ] || mkdir -p $XDG_STATE_HOME
+
+# Bash history file
+BASH_HISTFILE_HOME="$XDG_STATE_HOME/bash"
+export HISTFILE="$BASH_HISTFILE_HOME/history"
+[ -d $BASH_HISTFILE_HOME ] || mkdir -p $BASH_HISTFILE_HOME

--- a/.profile
+++ b/.profile
@@ -21,11 +21,15 @@ export PATH="$PATH:$ANDROID_HOME/platform-tools"
 # Flutter requires `CHROME_EXECUTABLE` to develop for the web
 export CHROME_EXECUTABLE="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
 
-# Added by Cargo
-. "$HOME/.cargo/env"
-
 # Added by Toolbox App
 export PATH="$PATH:/usr/local/bin"
 
+# Added by Cargo
+if [[ -d "$HOME/.cargo" ]]; then
+  . "$HOME/.cargo/env"
+fi
+
 # Added by Docker Desktop
-source "$HOME/.docker/init-bash.sh" || true
+if [[ -d "$HOME/.docker" ]]; then
+  source "$HOME/.docker/init-bash.sh" || true
+fi

--- a/.profile
+++ b/.profile
@@ -1,3 +1,31 @@
+# Set default editor to Neovim
+export EDITOR=nvim
+
+# Set default configuration folder to `~/.config`
+export XDG_CONFIG_HOME="$HOME/.config"
+
+# TODO: Move all Zsh config files EXCEPT .zshenv
+# export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
+
+# PNPM
+export PNPM_HOME="$HOME/Library/pnpm"
+export PATH="$PNPM_HOME:$PATH"
+
+# Android
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$PATH:$ANDROID_HOME/emulator"
+export PATH="$PATH:$ANDROID_HOME/tools"
+export PATH="$PATH:$ANDROID_HOME/tools/bin"
+export PATH="$PATH:$ANDROID_HOME/platform-tools"
+
+# Flutter requires `CHROME_EXECUTABLE` to develop for the web
+export CHROME_EXECUTABLE="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+
+# Added by Cargo
 . "$HOME/.cargo/env"
 
-source "$HOME/.docker/init-bash.sh" || true # Added by Docker Desktop
+# Added by Toolbox App
+export PATH="$PATH:/usr/local/bin"
+
+# Added by Docker Desktop
+source "$HOME/.docker/init-bash.sh" || true

--- a/.profile
+++ b/.profile
@@ -7,29 +7,33 @@ export XDG_CONFIG_HOME="$HOME/.config"
 # TODO: Move all Zsh config files EXCEPT .zshenv
 # export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 
-# PNPM
-export PNPM_HOME="$HOME/Library/pnpm"
-export PATH="$PNPM_HOME:$PATH"
+case "$HOST" in
+  taseen-macbook-work.local)
+    # PNPM
+    export PNPM_HOME="$HOME/Library/pnpm"
+    export PATH="$PNPM_HOME:$PATH"
 
-# Android
-export ANDROID_HOME="$HOME/Library/Android/sdk"
-export PATH="$PATH:$ANDROID_HOME/emulator"
-export PATH="$PATH:$ANDROID_HOME/tools"
-export PATH="$PATH:$ANDROID_HOME/tools/bin"
-export PATH="$PATH:$ANDROID_HOME/platform-tools"
+    # Android
+    export ANDROID_HOME="$HOME/Library/Android/sdk"
+    export PATH="$PATH:$ANDROID_HOME/emulator"
+    export PATH="$PATH:$ANDROID_HOME/tools"
+    export PATH="$PATH:$ANDROID_HOME/tools/bin"
+    export PATH="$PATH:$ANDROID_HOME/platform-tools"
 
-# Flutter requires `CHROME_EXECUTABLE` to develop for the web
-export CHROME_EXECUTABLE="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+    # Flutter requires `CHROME_EXECUTABLE` to develop for the web
+    export CHROME_EXECUTABLE="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
 
-# Added by Toolbox App
-export PATH="$PATH:/usr/local/bin"
+    # Added by Toolbox App
+    export PATH="$PATH:/usr/local/bin"
 
-# Added by Cargo
-if [[ -d "$HOME/.cargo" ]]; then
-  . "$HOME/.cargo/env"
-fi
+    # Added by Docker Desktop
+    source "$HOME/.docker/init-bash.sh" || true
 
-# Added by Docker Desktop
-if [[ -d "$HOME/.docker" ]]; then
-  source "$HOME/.docker/init-bash.sh" || true
-fi
+    # Added by Cargo
+    . "$HOME/.cargo/env"
+    ;;
+
+  taseen-mint)
+    # Nothing here yet...
+    ;;
+esac

--- a/.zprofile
+++ b/.zprofile
@@ -1,5 +1,0 @@
-
-
-# Added by Toolbox App
-export PATH="$PATH:/usr/local/bin"
-

--- a/.zprofile
+++ b/.zprofile
@@ -18,10 +18,6 @@
 #
 # SEE: https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
 
-# Dump completion artefacts into a cache directory.
-# Oh My Zsh sets `ZSH_CACHE_DIR` to `$ZSH/cache` by default.
-export ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${(%):-%m}-${ZSH_VERSION}"
-
 case "$HOST" in
   taseen-macbook-work.local)
     # PNPM

--- a/.zprofile
+++ b/.zprofile
@@ -1,0 +1,22 @@
+#!/bin/zsh
+#
+# .zprofile - Zsh file loaded on login.
+#
+
+# NOTE: To avoid potential issues that `path_helper` may cause when prepending
+# appending and prepending to `$PATH`, all environment variables will be set
+# in this file. Refer to the link below for more information.
+#
+# > For zsh, the order is like this:
+# > 1. `/etc/zshenv` (no longer exists on macOS by default)
+# > 2. `~/.zshenv`
+# > 3. login mode:
+# >   i.  `/etc/zprofile` (calling `path_helper`)
+# >   ii. `~/.zprofile`
+# > 4. interactive: `/etc/zshrc` `~/.zshrc`
+# > 5. login mode: `/etc/zlogin` `~/.zlogin`
+#
+# SEE: https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
+
+# Share environment variables between Bash and Zsh.
+source "$HOME/.profile"

--- a/.zprofile
+++ b/.zprofile
@@ -18,5 +18,38 @@
 #
 # SEE: https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
 
-# Share environment variables between Bash and Zsh.
-source "$HOME/.profile"
+# Dump completion artefacts into a cache directory.
+# Oh My Zsh sets `ZSH_CACHE_DIR` to `$ZSH/cache` by default.
+export ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${(%):-%m}-${ZSH_VERSION}"
+
+case "$HOST" in
+  taseen-macbook-work.local)
+    # PNPM
+    export PNPM_HOME="$HOME/Library/pnpm"
+    export PATH="$PNPM_HOME:$PATH"
+
+    # Android
+    export ANDROID_HOME="$HOME/Library/Android/sdk"
+    export PATH="$PATH:$ANDROID_HOME/emulator"
+    export PATH="$PATH:$ANDROID_HOME/tools"
+    export PATH="$PATH:$ANDROID_HOME/tools/bin"
+    export PATH="$PATH:$ANDROID_HOME/platform-tools"
+
+    # Flutter requires `CHROME_EXECUTABLE` to develop for the web
+    export CHROME_EXECUTABLE="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+
+    # Added by Toolbox App
+    # TODO: This appears to be redudant?
+    export PATH="$PATH:/usr/local/bin"
+
+    # Added by Docker Desktop
+    source "$HOME/.docker/init-bash.sh" || true
+
+    # Added by Cargo
+    . "$HOME/.cargo/env"
+    ;;
+
+  taseen-mint)
+    # Nothing here yet...
+    ;;
+esac

--- a/.zshenv
+++ b/.zshenv
@@ -8,5 +8,5 @@ source "$HOME/.profile"
 
 # NOTE: This file needs to live at ~/.zshenv, not in $ZDOTDIR!
 
-# TODO: Move all Zsh config files EXCEPT .zshenv
-# export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
+# All other Zsh files are located in the config folder.
+export ZDOTDIR="$XDG_CONFIG_HOME/zsh"

--- a/.zshenv
+++ b/.zshenv
@@ -3,6 +3,10 @@
 # .zshenv - Zsh environment file, loaded always.
 #
 
+# Share environment variables between Bash and Zsh.
+source "$HOME/.profile"
+
 # NOTE: This file needs to live at ~/.zshenv, not in $ZDOTDIR!
+
 # TODO: Move all Zsh config files EXCEPT .zshenv
 # export ZDOTDIR="$XDG_CONFIG_HOME/zsh"

--- a/.zshenv
+++ b/.zshenv
@@ -3,7 +3,6 @@
 # .zshenv - Zsh environment file, loaded always.
 #
 
-# NOTE: .zshenv needs to live at ~/.zshenv, not in $ZDOTDIR!
-
-# Share environment variables between Bash and Zsh.
-source "$HOME/.profile"
+# NOTE: This file needs to live at ~/.zshenv, not in $ZDOTDIR!
+# TODO: Move all Zsh config files EXCEPT .zshenv
+# export ZDOTDIR="$XDG_CONFIG_HOME/zsh"

--- a/.zshenv
+++ b/.zshenv
@@ -3,10 +3,10 @@
 # .zshenv - Zsh environment file, loaded always.
 #
 
+# NOTE: This file needs to live at ~/.zshenv, not in $ZDOTDIR!
+
 # Share environment variables between Bash and Zsh.
 source "$HOME/.profile"
-
-# NOTE: This file needs to live at ~/.zshenv, not in $ZDOTDIR!
 
 # All other Zsh files are located in the config folder.
 export ZDOTDIR="$XDG_CONFIG_HOME/zsh"

--- a/.zshenv
+++ b/.zshenv
@@ -1,1 +1,9 @@
-. "$HOME/.cargo/env"
+#!/bin/zsh
+#
+# .zshenv - Zsh environment file, loaded always.
+#
+
+# NOTE: .zshenv needs to live at ~/.zshenv, not in $ZDOTDIR!
+
+# Share environment variables between Bash and Zsh.
+source "$HOME/.profile"

--- a/.zshrc
+++ b/.zshrc
@@ -82,12 +82,6 @@ source $ZSH/oh-my-zsh.sh
 # terminal to use to request the passphrase.
 export GPG_TTY=$(tty)
 
-# Added by Docker Desktop
-# TODO: Since this is already sourced in `~/.profile`, is this needed?
-if [[ -d "$HOME/.docker" ]]; then
-  source "$HOME/.docker/init-zsh.sh" || true
-fi
-
 # Load rbenv in the shell
 if (( $+commands[rbenv] )); then
   zsh-defer eval "$(rbenv init - zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -62,7 +62,14 @@ HIST_STAMPS="yyyy-mm-dd"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git macos zsh-syntax-highlighting zsh-defer vi-mode)
+plugins=(
+  autoupdate
+  git
+  macos
+  vi-mode
+  zsh-defer
+  zsh-syntax-highlighting
+)
 
 source $ZSH/oh-my-zsh.sh
 
@@ -77,7 +84,9 @@ export GPG_TTY=$(tty)
 
 # Added by Docker Desktop
 # TODO: Since this is already sourced in `~/.profile`, is this needed?
-source "$HOME/.docker/init-zsh.sh" || true
+if [[ -d "$HOME/.docker" ]]; then
+  source "$HOME/.docker/init-zsh.sh" || true
+fi
 
 # Load rbenv in the shell
 if (( $+commands[rbenv] )); then

--- a/.zshrc
+++ b/.zshrc
@@ -71,6 +71,25 @@ plugins=(
   zsh-syntax-highlighting
 )
 
+# By default, OMZ sets the cache directory to "$ZSH/cache", but we'll prefer
+# "$XDG_CACHE_HOME/zsh" if possible.
+if (( ${+XDG_CACHE_HOME} )); then
+  export ZSH_CACHE_DIR="$XDG_CACHE_HOME/zsh"
+else
+  export ZSH_CACHE_DIR="$ZSH/cache"
+fi
+
+# Dump completion artefacts into a cache directory, appended with the machine's
+# hostname (without any domain information^1) and current ZSH version.
+#
+# Borrowed from:
+# - https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624221366
+# - https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624451063
+#
+# [1]: Equivalent to `hostname -s` on BSD systems
+#      https://man.freebsd.org/cgi/man.cgi?hostname(1)
+export ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${HOST/.*/}-${ZSH_VERSION}"
+
 source $ZSH/oh-my-zsh.sh
 
 # User configuration

--- a/.zshrc
+++ b/.zshrc
@@ -1,4 +1,7 @@
-############################## Zsh Configuration ###############################
+#!/bin/zsh
+#
+# .zshrc - Zsh file loaded on interactive shell sessions.
+#
 
 # Path to your oh-my-zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
@@ -69,24 +72,12 @@ source $ZSH/oh-my-zsh.sh
 # export LANG=en_US.UTF-8
 
 # GPG may require passphrase every now and then - this line lets it know which
-# terminal to use to request the passphrase
+# terminal to use to request the passphrase.
 export GPG_TTY=$(tty)
 
-# PNPM
-export PNPM_HOME="$HOME/Library/pnpm"
-export PATH="$PNPM_HOME:$PATH"
-
-# Android
-export ANDROID_HOME="$HOME/Library/Android/sdk"
-export PATH="$PATH:$ANDROID_HOME/emulator"
-export PATH="$PATH:$ANDROID_HOME/tools"
-export PATH="$PATH:$ANDROID_HOME/tools/bin"
-export PATH="$PATH:$ANDROID_HOME/platform-tools"
-
-# Flutter requires `CHROME_EXECUTABLE` to develop for the web
-export CHROME_EXECUTABLE="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
-
-source "$HOME/.docker/init-zsh.sh" || true # Added by Docker Desktop
+# Added by Docker Desktop
+# TODO: Since this is already sourced in `~/.profile`, is this needed?
+source "$HOME/.docker/init-zsh.sh" || true
 
 # Load rbenv in the shell
 zsh-defer eval "$(rbenv init - zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -80,14 +80,20 @@ export GPG_TTY=$(tty)
 source "$HOME/.docker/init-zsh.sh" || true
 
 # Load rbenv in the shell
-zsh-defer eval "$(rbenv init - zsh)"
+if (( $+commands[rbenv] )); then
+  zsh-defer eval "$(rbenv init - zsh)"
+fi
 
 # fnm
-zsh-defer eval "$(fnm env --use-on-cd)"
+if (( $+commands[fnm] )); then
+  zsh-defer eval "$(fnm env --use-on-cd)"
+fi
 
 # jEnv
-export PATH="$HOME/.jenv/bin:$PATH"
-zsh-defer eval "$(jenv init -)"
+if (( $+commands[jenv] )); then
+  export PATH="$HOME/.jenv/bin:$PATH"
+  zsh-defer eval "$(jenv init -)"
+fi
 
 # Customise prompt
 DEFAULT_USER=$USER

--- a/README.md
+++ b/README.md
@@ -35,15 +35,21 @@ $ ls -al ~
 lrwxr-xr-x    1 taseen  staff     17  5 Mar 00:16 .bashrc -> .dotfiles/.bashrc
 lrwxr-xr-x    1 taseen  staff     20  5 Mar 00:16 .gitconfig -> .dotfiles/.gitconfig
 lrwxr-xr-x    1 taseen  staff     18  5 Mar 00:16 .profile -> .dotfiles/.profile
-lrwxr-xr-x    1 taseen  staff     19  5 Mar 00:16 .zprofile -> .dotfiles/.zprofile
 lrwxr-xr-x    1 taseen  staff     17  5 Mar 00:16 .zshenv -> .dotfiles/.zshenv
 lrwxr-xr-x    1 taseen  staff     16  5 Mar 00:16 .zshrc -> .dotfiles/.zshrc
+# ... and so on ...
 
 $ ls -al ~/.config
+lrwxr-xr-x   1 taseen  staff    25  5 Mar 00:16 bat -> ../.dotfiles/.config/bat
+lrwxr-xr-x   1 taseen  staff    25  5 Mar 00:16 kitty -> ../.dotfiles/.config/kitty
+lrwxr-xr-x   1 taseen  staff    25  5 Mar 00:16 lazygit -> ../.dotfiles/.config/lazygit
 lrwxr-xr-x   1 taseen  staff    25  5 Mar 00:16 nvim -> ../.dotfiles/.config/nvim
 lrwxr-xr-x   1 taseen  staff    25  5 Mar 00:16 skhd -> ../.dotfiles/.config/skhd
 lrwxr-xr-x   1 taseen  staff    26  5 Mar 00:16 yabai -> ../.dotfiles/.config/yabai
+# ... and so on ...
 ```
+
+> NOTE: The output above is only a short snippet to serve as an example. You may have a different output.
 
 ## Further reading
 


### PR DESCRIPTION
Define `EDITOR` and XDG Base Directory variables in `~/.profile` so that Bash and Zsh share the same base variables. Regarding the XDG Base Directories, if any of the directories do not exist, create them. Even though I primarily use macOS, I have chosen to adopt the XDG Base Directories as it is the de facto standard for storing configurations, among other things, for CLI applications running on Unix-like systems.

Move Zsh files (except `.zshenv`) into `XDG_CONFIG_HOME` to declutter the home directory. Redirect Zsh files related to cache and application state (specifically `.zsh_history` and `.zcompdump*` files) away from the home directory.

Define host-specific variables in `~/.config/zsh/.zprofile` to avoid `path_helper` from causing potential issues when appending and prepending to `PATH`.

Add conditional checks before running initialisation logic for `rbenv`, `fnm`, and `jenv` to ensure they are only run if they are actually installed.