### PR TITLE
chore(lazygit): configure gui options

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,5 +1,18 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/jesseduffield/lazygit/1a035db4c817ac07cd59f0f2aa4e1efd1a9b75b6/schema/config.json
 git:
   paging:
     colorArg: always
     pager: delta --dark --color-only --paging=never
+gui:
+  showFileTree: false
+  nerdFontsVersion: '3'
+  theme:
+    selectedLineBgColor:
+      - reverse
+      - bold
+    # NOTE: This field has been deprecated in `master` in favour of `selectedLineBgColor`.
+    # SEE: https://github.com/jesseduffield/lazygit/pull/3207
+    # SEE: https://github.com/jesseduffield/lazygit/issues/3386
+    selectedRangeBgColor:
+      - reverse
+      - bold


### PR DESCRIPTION
Customises background colours, activates Nerd Font icons, and disables file tree as default file explorer.

The YAML schema has also been pinned to the earliest version since the latest stable `lazygit` version is a few months behind `master`.