### PR TITLE
fix(stow): add missing ignore rules

### DIFF
--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -11,6 +11,8 @@ _darcs
 
 \.git
 \.gitignore
+\.gitmodules
+\.ignore
 
 .+~          # emacs backup files
 \#.*\#       # emacs autosave files


### PR DESCRIPTION
Rename `.stow-global-ignore` to `.stow-local-ignore` to correctly follow documentation for ignoring files in GNU Stow.

Add `.gitmodules` and `.ignore` to same ignore list to avoid them being symlinked into target directory.

Fixes: #12, #13 