### PR TITLE
feature(brew): generate `Brewfile`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -28,8 +28,6 @@ brew "fd"
 brew "ffmpeg"
 # Fast and simple Node.js version manager
 brew "fnm"
-# Command-line outline and bitmap font editor/converter
-brew "fontforge"
 # GitHub command-line tool
 brew "gh"
 # Syntax-highlighting pager for git and diff output
@@ -38,8 +36,6 @@ brew "git-delta"
 brew "imagemagick"
 # Manage your Java environment
 brew "jenv"
-# Manipulate OpenType and multiple-master fonts
-brew "lcdf-typetools"
 # Ambitious Vim-fork focused on extensibility and agility
 brew "neovim"
 # Development kit for the Java programming language

--- a/Brewfile
+++ b/Brewfile
@@ -9,7 +9,6 @@ is_work_machine = (hostname == "taseen-macbook-work")
 
 # ---[ Taps ]------------------------------------------------------------------
 
-tap "fsouza/prettierd"
 tap "homebrew/bundle"
 tap "homebrew/cask-fonts"
 tap "homebrew/services"
@@ -43,8 +42,6 @@ brew "jenv"
 brew "lcdf-typetools"
 # Ambitious Vim-fork focused on extensibility and agility
 brew "neovim"
-# Platform built on V8 to build network applications
-brew "node", link: false
 # Development kit for the Java programming language
 brew "openjdk@11"
 # Development kit for the Java programming language
@@ -63,8 +60,6 @@ brew "ripgrep"
 brew "stow"
 # Check your $HOME for unwanted files and directories
 brew "xdg-ninja"
-# prettier, on SPEED!
-brew "fsouza/prettierd/prettierd"
 # A simple terminal UI for git commands, written in Go
 brew "jesseduffield/lazygit/lazygit"
 # Simple hotkey-daemon for macOS.
@@ -88,10 +83,6 @@ cask "racket"
 # ===[ WORK MACHINE BREWFILE ]=================================================
 
 if is_work_machine then
-  # ---[ Taps ]----------------------------------------------------------------
-
-  tap "shopify/shopify"
-
   # ---[ Formulae ]------------------------------------------------------------
 
   # Enables you to reproduce the CircleCI environment locally
@@ -106,10 +97,6 @@ if is_work_machine then
   brew "scrcpy"
   # Validating, recursive, caching DNS resolver
   brew "unbound"
-  # A CLI tool to build for the Shopify platform
-  brew "shopify/shopify/shopify-cli"
-  # Theme Kit is a tool kit for manipulating shopify themes
-  brew "shopify/shopify/themekit"
 
   # ---[ Casks ]---------------------------------------------------------------
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,14 @@
+# Brewfile
+# Generated with: brew bundle dump --describe --cask --formula --tap
 # vim: ft=ruby
+
+hostname = `hostname -s`.strip
+is_work_machine = (hostname == "taseen-macbook-work")
+
+# ===[ SHARED BREWFILE ]=======================================================
+
+# ---[ Taps ]------------------------------------------------------------------
+
 tap "fsouza/prettierd"
 tap "homebrew/bundle"
 tap "homebrew/cask-fonts"
@@ -6,19 +16,15 @@ tap "homebrew/services"
 tap "jesseduffield/lazygit"
 tap "koekeishiya/formulae"
 tap "oven-sh/bun"
-tap "shopify/shopify"
+
+# ---[ Formulae ]--------------------------------------------------------------
+
 # Text processor and publishing toolchain for AsciiDoc
 brew "asciidoctor"
 # Clone of cat(1) with syntax highlighting and Git integration
 brew "bat"
-# Enables you to reproduce the CircleCI environment locally
-brew "circleci"
 # Simple, fast and user-friendly alternative to find
 brew "fd"
-# Validating, recursive, caching DNS resolver
-brew "unbound"
-# GNU Transport Layer Security (TLS) Library
-brew "gnutls"
 # Play, record, convert, and stream audio and video
 brew "ffmpeg"
 # Fast and simple Node.js version manager
@@ -31,14 +37,10 @@ brew "gh"
 brew "git-delta"
 # Tools and libraries to manipulate images in many formats
 brew "imagemagick"
-# Install and debug iPhone apps from the command-line
-brew "ios-deploy"
 # Manage your Java environment
 brew "jenv"
 # Manipulate OpenType and multiple-master fonts
 brew "lcdf-typetools"
-# Netwide Assembler (NASM) is an 80x86 assembler
-brew "nasm"
 # Ambitious Vim-fork focused on extensibility and agility
 brew "neovim"
 # Platform built on V8 to build network applications
@@ -51,18 +53,12 @@ brew "openjdk@17"
 brew "openjdk@8"
 # Swiss-army knife of markup format conversion
 brew "pandoc"
-# Object-relational database system
-brew "postgresql@14"
 # File browser
 brew "ranger"
 # Ruby version manager
 brew "rbenv"
-# Persistent key-value database, with built-in net interface
-brew "redis"
 # Search tool like grep and The Silver Searcher
 brew "ripgrep"
-# Display and control your Android device
-brew "scrcpy"
 # Organize software neatly under a single directory tree (e.g. /usr/local)
 brew "stow"
 # Check your $HOME for unwanted files and directories
@@ -77,17 +73,46 @@ brew "koekeishiya/formulae/skhd"
 brew "koekeishiya/formulae/yabai"
 # Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.
 brew "oven-sh/bun/bun"
-# A CLI tool to build for the Shopify platform
-brew "shopify/shopify/shopify-cli"
-# Theme Kit is a tool kit for manipulating shopify themes
-brew "shopify/shopify/themekit"
+
+# ---[ Casks ]-----------------------------------------------------------------
+
 # Compact TeX distribution as alternative to the full TeX Live / MacTeX
 cask "basictex"
-# UI toolkit for building applications for mobile, web and desktop
-cask "flutter"
 # Developer targeted fonts with a high number of glyphs
 cask "font-symbols-only-nerd-font"
 # GPU-based terminal emulator
 cask "kitty"
 # Modern programming language in the Lisp/Scheme family
 cask "racket"
+
+# ===[ WORK MACHINE BREWFILE ]=================================================
+
+if is_work_machine then
+  # ---[ Taps ]----------------------------------------------------------------
+
+  tap "shopify/shopify"
+
+  # ---[ Formulae ]------------------------------------------------------------
+
+  # Enables you to reproduce the CircleCI environment locally
+  brew "circleci"
+  # GNU Transport Layer Security (TLS) Library
+  brew "gnutls"
+  # Install and debug iPhone apps from the command-line
+  brew "ios-deploy"
+  # Object-relational database system
+  brew "postgresql@14"
+  # Display and control your Android device
+  brew "scrcpy"
+  # Validating, recursive, caching DNS resolver
+  brew "unbound"
+  # A CLI tool to build for the Shopify platform
+  brew "shopify/shopify/shopify-cli"
+  # Theme Kit is a tool kit for manipulating shopify themes
+  brew "shopify/shopify/themekit"
+
+  # ---[ Casks ]---------------------------------------------------------------
+
+  # UI toolkit for building applications for mobile, web and desktop
+  cask "flutter"
+end

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,93 @@
+# vim: ft=ruby
+tap "fsouza/prettierd"
+tap "homebrew/bundle"
+tap "homebrew/cask-fonts"
+tap "homebrew/services"
+tap "jesseduffield/lazygit"
+tap "koekeishiya/formulae"
+tap "oven-sh/bun"
+tap "shopify/shopify"
+# Text processor and publishing toolchain for AsciiDoc
+brew "asciidoctor"
+# Clone of cat(1) with syntax highlighting and Git integration
+brew "bat"
+# Enables you to reproduce the CircleCI environment locally
+brew "circleci"
+# Simple, fast and user-friendly alternative to find
+brew "fd"
+# Validating, recursive, caching DNS resolver
+brew "unbound"
+# GNU Transport Layer Security (TLS) Library
+brew "gnutls"
+# Play, record, convert, and stream audio and video
+brew "ffmpeg"
+# Fast and simple Node.js version manager
+brew "fnm"
+# Command-line outline and bitmap font editor/converter
+brew "fontforge"
+# GitHub command-line tool
+brew "gh"
+# Syntax-highlighting pager for git and diff output
+brew "git-delta"
+# Tools and libraries to manipulate images in many formats
+brew "imagemagick"
+# Install and debug iPhone apps from the command-line
+brew "ios-deploy"
+# Manage your Java environment
+brew "jenv"
+# Manipulate OpenType and multiple-master fonts
+brew "lcdf-typetools"
+# Netwide Assembler (NASM) is an 80x86 assembler
+brew "nasm"
+# Ambitious Vim-fork focused on extensibility and agility
+brew "neovim"
+# Platform built on V8 to build network applications
+brew "node", link: false
+# Development kit for the Java programming language
+brew "openjdk@11"
+# Development kit for the Java programming language
+brew "openjdk@17"
+# Development kit for the Java programming language
+brew "openjdk@8"
+# Swiss-army knife of markup format conversion
+brew "pandoc"
+# Object-relational database system
+brew "postgresql@14"
+# File browser
+brew "ranger"
+# Ruby version manager
+brew "rbenv"
+# Persistent key-value database, with built-in net interface
+brew "redis"
+# Search tool like grep and The Silver Searcher
+brew "ripgrep"
+# Display and control your Android device
+brew "scrcpy"
+# Organize software neatly under a single directory tree (e.g. /usr/local)
+brew "stow"
+# Check your $HOME for unwanted files and directories
+brew "xdg-ninja"
+# prettier, on SPEED!
+brew "fsouza/prettierd/prettierd"
+# A simple terminal UI for git commands, written in Go
+brew "jesseduffield/lazygit/lazygit"
+# Simple hotkey-daemon for macOS.
+brew "koekeishiya/formulae/skhd"
+# A tiling window manager for macOS based on binary space partitioning.
+brew "koekeishiya/formulae/yabai"
+# Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.
+brew "oven-sh/bun/bun"
+# A CLI tool to build for the Shopify platform
+brew "shopify/shopify/shopify-cli"
+# Theme Kit is a tool kit for manipulating shopify themes
+brew "shopify/shopify/themekit"
+# Compact TeX distribution as alternative to the full TeX Live / MacTeX
+cask "basictex"
+# UI toolkit for building applications for mobile, web and desktop
+cask "flutter"
+# Developer targeted fonts with a high number of glyphs
+cask "font-symbols-only-nerd-font"
+# GPU-based terminal emulator
+cask "kitty"
+# Modern programming language in the Lisp/Scheme family
+cask "racket"


### PR DESCRIPTION
Add `Brewfile` to track Homebrew formulae and casks to install across machines. Host-specific software are determined by checking the machine's hostname with `hostname -s`. Note that the `-s` command is only available on BSD systems.

To install the software specified in `Brewfile`, cd into the home directory (or wherever `stow` symlinks the dotfiles) and run `brew bundle install`. Once successful, it will generate `Brewfile.lock.json` in the same directory -- there is no need to commit this file as it is only used by `brew bundle` for troubleshooting.

Since Homebrew is a rolling release package manager, it does not support installing arbitrary older versions of software. As a result, `Brewfile` only informs Homebrew to install the latest versions of the listed formulae and casks.