### PR TITLE
chore(kitty)!: replace "Open URL" shortcut with "Copy URL"

### DIFF
--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -2212,9 +2212,9 @@ map cmd+t       new_tab_with_cwd
 #: external program or insert it into the terminal or copy it to the
 #: clipboard.
 
-#: Open URL
+#: Copy URL
 
-# map kitty_mod+e open_url_with_hints
+map kitty_mod+e kitten hints --type url --program @
 
 #::  Open a currently visible URL using the keyboard. The program used
 #::  to open the URL is specified in open_url_with.


### PR DESCRIPTION
Replace "Open URL" shortcut with custom "Copy URL" shortcut. I find myself wanting to copy URLs more often than opening URLs with the default browser.

`kitten hints` is a feature of `kitty` to select and act on arbitrarily text snippets currently visible on screen. `--type url` instructs `kitty` to search for URLs currently visible on screen. `--program @` instructs `kitty` to copy the matched URL to the clipboard.