### PR TITLE
chore(git): move config file

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -29,8 +29,6 @@
 [pull]
 	ff = only
 
-# The contents of this file are included only for GitLab.com URLs
+# UTS GitLab repositories
 [includeIf "hasconfig:remote.*.url:https://code.research.uts.edu.au/**"]
-
-# Edit this line to point to your alternate configuration file
-path = ~/.gitconfig-uts
+	path = ./config-uts


### PR DESCRIPTION
Move global Git config file from `~/.gitconfig` to `$XDG_CONFIG_HOME/git/config`.

Also update path to the Git config file specific to UTS GitLab repositories. Note that this file is not version controlled since it includes sensitive values. As such, this file MUST be present at `$XDG_CONFIG_HOME/git/config-uts`. Ideally, this file should be present before running GNU Stow to ensure only `$XDG_CONFIG_HOME/git/config` is symlinked, and not the directory itself (`$XDG_CONFIG_HOME/git`).