### PR TITLE
feat(ranger): add support for previewing images

### DIFF
--- a/.config/ranger/rc.conf
+++ b/.config/ranger/rc.conf
@@ -1,0 +1,2 @@
+set preview_images true
+set preview_images_method kitty

--- a/Brewfile
+++ b/Brewfile
@@ -48,6 +48,8 @@ brew "openjdk@17"
 brew "openjdk@8"
 # Swiss-army knife of markup format conversion
 brew "pandoc"
+# Friendly PIL fork (Python Imaging Library)
+brew "pillow"
 # File browser
 brew "ranger"
 # Ruby version manager


### PR DESCRIPTION
Enable image preview support for `ranger` using the `kitty` image protocol. Uses external dependency `pillow` to render the image.