### PR TITLE
chore(git): define Git `signingkey` for UTS repositories

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -1,3 +1,5 @@
+# vim:ft=gitconfig:tabstop=2
+
 [user]
 	name = Ta-Seen
 	email = taseen00.islam@gmail.com

--- a/.config/git/config-uts
+++ b/.config/git/config-uts
@@ -1,0 +1,6 @@
+# vim:ft=gitconfig:tabstop=2
+
+[user]
+	name = Ta-Seen Islam
+	email = ta-seen.islam@student.uts.edu.au
+	signingkey = 7205190889D2FEB0


### PR DESCRIPTION
Define `signingkey` and other user properties for UTS GitLab repositories. This configuration will be applied to all machines. Perhaps it would be nice to figure out how to load this file on specific machines, or even change the `signingkey`, as detailed in issue #23.

Add header comment in both Git configuration files so Vim and GitHub applies appropriate syntax highlighting.